### PR TITLE
Spot geometry

### DIFF
--- a/board.js
+++ b/board.js
@@ -30,6 +30,28 @@ let boardJSON = `{
                     "toPath": "Church History West",
                     "toSpot": 0
                 }
+            ],
+            "pins": [
+                {
+                    "spot": 0,
+                    "x": 0.5,
+                    "y": 0.05
+                },
+                {
+                    "spot": 15,
+                    "x": 0.95,
+                    "y": 0.5
+                },
+                {
+                    "spot": 30,
+                    "x": 0.5,
+                    "y": 0.95
+                },
+                {
+                    "spot": 45,
+                    "x": 0.05,
+                    "y": 0.5
+                }
             ]
         },
         {
@@ -58,6 +80,28 @@ let boardJSON = `{
                     "toPath": "Church History West",
                     "toSpot": 1
                 }
+            ],
+            "pins": [
+                {
+                    "spot": 0,
+                    "x": 0.5,
+                    "y": 0.35
+                },
+                {
+                    "spot": 5,
+                    "x": 0.65,
+                    "y": 0.5
+                },
+                {
+                    "spot": 10,
+                    "x": 0.5,
+                    "y": 0.65
+                },
+                {
+                    "spot": 15,
+                    "x": 0.35,
+                    "y": 0.5
+                }
             ]
         },
         {
@@ -75,6 +119,18 @@ let boardJSON = `{
                     "fromSpot": 1,
                     "toPath": "New Testament",
                     "toSpot": 0
+                }
+            ],
+            "pins": [
+                {
+                    "spot": 0,
+                    "x": 0.5,
+                    "y": 0.15
+                },
+                {
+                    "spot": -1,
+                    "x": 0.5,
+                    "y": 0.25
                 }
             ]
         },
@@ -94,6 +150,18 @@ let boardJSON = `{
                     "toPath": "New Testament",
                     "toSpot": 5
                 }
+            ],
+            "pins": [
+                {
+                    "spot": 0,
+                    "x": 0.85,
+                    "y": 0.5
+                },
+                {
+                    "spot": -1,
+                    "x": 0.75,
+                    "y": 0.5
+                }
             ]
         },
         {
@@ -112,6 +180,18 @@ let boardJSON = `{
                     "toPath": "New Testament",
                     "toSpot": 10
                 }
+            ],
+            "pins": [
+                {
+                    "spot": 0,
+                    "x": 0.5,
+                    "y": 0.85
+                },
+                {
+                    "spot": -1,
+                    "x": 0.5,
+                    "y": 0.75
+                }
             ]
         },
         {
@@ -129,6 +209,18 @@ let boardJSON = `{
                     "fromSpot": 1,
                     "toPath": "New Testament",
                     "toSpot": 15
+                }
+            ],
+            "pins": [
+                {
+                    "spot": 0,
+                    "x": 0.15,
+                    "y": 0.5
+                },
+                {
+                    "spot": -1,
+                    "x": 0.25,
+                    "y": 0.5
                 }
             ]
         }

--- a/games.js
+++ b/games.js
@@ -339,26 +339,19 @@ var startSpot = null;
         let pathSpots = new Array(currentPath.count);
 
         if(pathSpots.length >= 1) {
-            let s = pathSpots.length - 1;
-            pathSpots[s] = new Spot();
-            while(s >= 1) {
-                let spot = new Spot();
-                spot.next = pathSpots[s];
-                --s;
-                pathSpots[s] = spot;
-            }
-            if(currentPath.isCircular){
-                pathSpots[pathSpots.length - 1].next = pathSpots[0];
-            }
+            for(let s = 0; s < pathSpots.length; ++s)
+                pathSpots[s] = new Spot();
 
-            // create back links on bidirectional paths
-            if(currentPath.bidirectional){
-                for(s = 1; s < pathSpots.length; ++s){
+            // create intrapath links
+            for(let s = 1; s < pathSpots.length; ++s) {
+                pathSpots[s - 1].next = pathSpots[s];
+                if(currentPath.bidirectional)
                     pathSpots[s].back = pathSpots[s - 1];
-                }
-                if(currentPath.isCircular){
+            }
+            if(currentPath.isCircular) {
+                pathSpots[pathSpots.length - 1].next = pathSpots[0];
+                if(currentPath.bidirectional)
                     pathSpots[0].back = pathSpots[pathSpots.length - 1];
-                }
             }
         }
 

--- a/games.js
+++ b/games.js
@@ -322,7 +322,8 @@ var startSpot = null;
 
     // create paths and fill with spots
     for(let p = 0; p < board.paths.length; ++p) {
-        let pathSpots = new Array(board.paths[p].count);
+        let currentPath = board.paths[p];
+        let pathSpots = new Array(currentPath.count);
 
         if(pathSpots.length >= 1) {
             let s = pathSpots.length - 1;
@@ -333,22 +334,22 @@ var startSpot = null;
                 --s;
                 pathSpots[s] = spot;
             }
-            if(board.paths[p].isCircular){
+            if(currentPath.isCircular){
                 pathSpots[pathSpots.length - 1].next = pathSpots[0];
             }
 
             // create back links on bidirectional paths
-            if(board.paths[p].bidirectional){
+            if(currentPath.bidirectional){
                 for(s = 1; s < pathSpots.length; ++s){
                     pathSpots[s].back = pathSpots[s - 1];
                 }
-                if(board.paths[p].isCircular){
+                if(currentPath.isCircular){
                     pathSpots[0].back = pathSpots[pathSpots.length - 1];
                 }
             }
         }
 
-        mapOfPaths.set(board.paths[p].name, pathSpots);
+        mapOfPaths.set(currentPath.name, pathSpots);
     }
 
 

--- a/games.js
+++ b/games.js
@@ -281,7 +281,7 @@ var boardSchema = {
             "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": [ "name", "count", "isCircular", "bidirectional", "bridges" ],
+                "required": [ "name", "count", "isCircular", "bidirectional", "bridges", "pins" ],
                 "properties": {
                     "name": { "type": "string" },
                     "count": { "type": "integer" },
@@ -297,6 +297,19 @@ var boardSchema = {
                                 "fromSpot": { "type": "integer" },
                                 "toPath": { "type": "string" },
                                 "toSpot": { "type": "integer" }
+                            }
+                        }
+                    },
+                    "pins": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [ "spot", "x", "y" ],
+                            "properties": {
+                                "spot": { "type": "integer" },
+                                "x": { "type": "number" },
+                                "y": { "type": "number" }
                             }
                         }
                     }


### PR DESCRIPTION
Imagine each path on the board is a long rubber band. The band can be stretched into a desired shape by inserting push-pins into the board at specified points, and then wrapping the rubber band around each of the push-pins in turn.

This pull request extends the board JSON schema to include pin coordinates, but doesn't actually do anything with them yet. The plan is to assign the pin coordinates directly to the specified spots, and then linearly interpolate the coordinates for all other spots based on each non-pinned spot's distance from the nearest pinned spot in each direction along the same path.

(Also included are two separate commits that clean up the spot creation code a little in preparation for applying the pins.)